### PR TITLE
Add option to de-duplicate contributors by name

### DIFF
--- a/lib/Dist/Zilla/Plugin/ContributorsFromGit.pm
+++ b/lib/Dist/Zilla/Plugin/ContributorsFromGit.pm
@@ -118,6 +118,12 @@ phase.
 The list of contributors is also added to distribution metadata under the custom
 C<x_contributors> key.
 
+=for :stopwords shortlog committer
+
+If you have duplicate contributors because of differences in committer name
+or email you can use a C<.mailmap> file to canonicalize contributor names
+and emails.  See L<git help shortlog|git-shortlog(1)> for details.
+
 =head1 SEE ALSO
 
 L<Pod::Weaver::Section::Contributors>


### PR DESCRIPTION
to avoid differing email addresses across commits

What do you think about this?

If there are commits by the same name but different email addresses
it will show the address that sorts first... now that I think about it
maybe it would be better to use the one in the most recent commit. :-/

Or do you think it would be better with just explicit include/exclude entries?
I could prepopulate the exclude list with my github email
(since most of my commits don't use my cpan email).
