### PR TITLE
Decode git log output as UTF-8

### DIFF
--- a/lib/Dist/Zilla/Plugin/ContributorsFromGit.pm
+++ b/lib/Dist/Zilla/Plugin/ContributorsFromGit.pm
@@ -2,6 +2,7 @@ package Dist::Zilla::Plugin::ContributorsFromGit;
 
 # ABSTRACT: Populate your 'CONTRIBUTORS' POD from the list of git authors
 
+use Encode qw(decode_utf8);
 use Moose;
 use namespace::autoclean;
 use MooseX::AttributeShortcuts 0.015;
@@ -35,7 +36,7 @@ has contributor_list => (
         my @contributors = uniq sort
             grep  { $_ ne 'Your Name <you@example.com>' }
             grep  { none(@authors) eq $_                }
-            apply { chomp                               }
+            apply { chomp; $_ = decode_utf8($_)         }
             `git log --format="%aN <%aE>"`
             ;
 


### PR DESCRIPTION
This patch decodes committer's names and email as UTF-8, so that generated META files will have correctly encoded Unicode strings in the JSON output: Here's the diff for META.json for Plack, generated with the fix: https://gist.github.com/miyagawa/5289388
