### PR TITLE
use shortlog instead of log

### DIFF
--- a/lib/Dist/Zilla/Plugin/ContributorsFromGit.pm
+++ b/lib/Dist/Zilla/Plugin/ContributorsFromGit.pm
@@ -35,11 +35,11 @@ has contributor_list => (
         my @authors = $self->zilla->authors->flatten;
 
         ### and get our list from git, filtering: "@authors"
-        my @contributors = uniq sort
+        my @contributors =
             grep  { $_ ne 'Your Name <you@example.com>' }
             grep  { none(@authors) eq $_                }
-            apply { chomp; $_ = decode_utf8($_)         }
-            `git log --format="%aN <%aE>"`
+            apply { chomp; s/\s*\d+\s*//; $_ = decode_utf8($_) }
+            `git shortlog -s -e`
             ;
 
         return \@contributors;


### PR DESCRIPTION
This is just a very minor optimization.  It uses shortlog instead of log to get the list of contributors.  shortlog -s shows authors with the number of commits they created, ordered by author name.  This eliminates the need to use sort or uniq on the list.
