### PR TITLE
fix #14

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -14,6 +14,10 @@ use File::Which 'which';
 use IPC::System::Simple (); # explicit dep for autodie system
 use Path::Class;
 
+use Encode qw(encode decode_utf8);
+use Term::Encoding 'term_encoding';
+my $term_encoding = term_encoding();
+
 use lib 't/lib';
 
 plan skip_all => 'git not found'
@@ -25,7 +29,10 @@ my $dist_root = $ds->base;
 my @AUTHORS = (
     'Some One <one@some.org>',
     'Another One <two@some.org>',
-    'James "宮川達彦" Salmoń <woo@bip.com>',
+    # encode the non-ascii author so that it survives printing twice
+    # (once via system() and once via git)
+    encode($term_encoding,
+        decode_utf8 'James 宮川達彦 Salmoń <woo@bip.com>'),
 );
 
 {


### PR DESCRIPTION
This fixes ticket #14 by encoding the non-ascii author name so that it
is compatible with whatever encoding the terminal is using. It uses
Terminal::Encoding to detect this. I have tested this on Windows, and
when combined with fixes for #13 and #15, basic.t passes.
