### PR TITLE
use Test::File::SD instead of F::SD::ProjectDistDir

### DIFF
--- a/lib/Dist/Zilla/Plugin/ContributorsFromGit.pm
+++ b/lib/Dist/Zilla/Plugin/ContributorsFromGit.pm
@@ -11,7 +11,7 @@ use autobox::Core;
 use autobox::Junctions;
 use File::Which 'which';
 use List::AllUtils qw{ max uniq };
-use File::ShareDir::ProjectDistDir;
+use File::ShareDir qw/ dist_dir /;
 use YAML::Tiny;
 use Path::Class;
 

--- a/t/author-map.t
+++ b/t/author-map.t
@@ -2,6 +2,12 @@ use strict;
 use warnings;
 use utf8;
 
+use Test::File::ShareDir -share => {
+    -dist => {
+        'Dist-Zilla-Plugin-ContributorsFromGit' => 'share',
+    },
+};
+
 use autodie 'system';
 use autobox::Core;
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -14,6 +14,13 @@ use File::Which 'which';
 use IPC::System::Simple (); # explicit dep for autodie system
 use Path::Class;
 
+use Test::File::ShareDir -share => {
+    -dist => {
+        'Dist-Zilla-Plugin-ContributorsFromGit' => 'share',
+    },
+};
+
+
 use lib 't/lib';
 
 plan skip_all => 'git not found'


### PR DESCRIPTION
File::SD::PDD looks in the parent directories and decides that
it's running from a work copy if there is a 'lib' directory
in there. Which breaks if, like me, your perlbrew is installed
under '/usr/local/soft/perlbrew' (the '/usr/local/lib' will trigger
the "Hey! /usr/local/ is our work dir" check)

Test::File::SD only fudges things for the tests, and is safer.