### PR TITLE
Do not run git-shortlog unless tree HEAD exists

### DIFF
--- a/lib/Dist/Zilla/Plugin/ContributorsFromGit.pm
+++ b/lib/Dist/Zilla/Plugin/ContributorsFromGit.pm
@@ -31,6 +31,9 @@ has _contributor_list => (
     isa     => 'ArrayRef[Str]',
     builder => sub {
         my $self = shift @_;
+
+        return [] unless `git show-ref HEAD`;
+
         my @authors = $self->zilla->authors->flatten;
 
         ### and get our list from git, filtering: "@authors"


### PR DESCRIPTION
running `git shortlog` in a directory where no HEAD exists
(or not git repository exists) produces this message:

(reading log message from standard input)

When git-shortlog receives no revisions, it will wait on a
log read from standard input

---

Hi, I use Dist::Milla to manage my modules, and ever since `git log` was replaced with `git shortlog`, I get this message when creating a new project (using `dist milla new $PROJECT-NAME`):

```
(reading log message from standard input)
```

...and I must `CTRL + C` before I can do anything else in the shell

I've chosen to check `git show-ref HEAD` as it will either return a revision or nothing (a non-true value).

If this seems unreasonable, please let me know and I'll be happy to try and come to another solution
